### PR TITLE
Revamp gameplay systems and UX for Stronghold v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-Still working on this, Simple hobbie project using AI, its a tower defense style game where you type words to kill enemies. you play as the Solflare King defending the stronghold from scammers! 
+# Solflare Stronghold v2
+
+A typing-defense browser game where you protect the Solflare Stronghold from waves of scammers.
+
+## What's new in v2
+
+- **Revamped progression:** adaptive spawn pacing, tougher waves, and elite enemies that require extra precision.
+- **Skill expression systems:** combo multiplier, accuracy tracking, kill streak rewards, and real-time performance HUD.
+- **Power/QoL upgrades:** pause (`P`), mute (`M`), improved restart flow, mobile typing support, and persistent high score.
+- **Validated content:** word bank sanitization at runtime (deduping/format checks + safe fallbacks) for stable gameplay.
+
+## Controls
+
+- Type enemy words to fire arrows.
+- Type `honda` when charged to unleash the car power.
+- `P` = pause, `M` = mute, `SPACE` = start/restart.
+- Mobile users can use on-screen keyboard input with focus auto-handling.
+
+## Run locally
+
+Open `index.html` in a browser (or serve with a simple static server) and press **Start**.

--- a/game.js
+++ b/game.js
@@ -2,7 +2,6 @@ const GAME_WIDTH = 1920;
 const GAME_HEIGHT = 1080;
 
 const DOOR_X = 1540;
-const DOOR_Y = 880;
 const DOOR_ENTRY_OFFSET = 40;
 
 const KING_WIDTH = 180;
@@ -10,42 +9,64 @@ const KING_HEIGHT = 220;
 
 const ENEMY_WIDTH = 300;
 const ENEMY_HEIGHT = 320;
+const ENEMY_LABEL_OFFSET_Y = 70;
 
-const ENEMY_LABEL_OFFSET_Y = 70; // Label above enemy
-const ARROW_SPEED = 700; // px/sec
-const TYPED_TEXT_Y = 150; // vertical position of typed words
+const ARROW_SPEED = 700;
+const TYPED_TEXT_Y = 140;
 const POWER_TEXT_Y = 200;
-const POWER_STREAK = 6;
-const MAX_POWER = 4;
+
+const POWER_STREAK = 5;
+const MAX_POWER = 5;
 const POWER_WORD = 'honda';
-const CAR_SPEED = 1.5; // slower for visible run over
+const CAR_SPEED = 1.85;
 
 const ENEMY_MIN_Y = GAME_HEIGHT * 0.85;
 const ENEMY_MAX_Y = GAME_HEIGHT * 0.93;
-const ENEMY_DEFAULT_Y = (ENEMY_MIN_Y + ENEMY_MAX_Y) / 2; // middle of the road
+const ENEMY_DEFAULT_Y = (ENEMY_MIN_Y + ENEMY_MAX_Y) / 2;
+const MIN_SPAWN_DISTANCE = ENEMY_WIDTH * 1.08;
 
-let archer, typed = "", typedText = null;
+const SAVE_KEY = 'solflare_stronghold_v2';
 
-let lives = 3;
+let archer;
+let typed = '';
+let typedText = null;
+let feedbackText = null;
+
+let lives = 5;
 let score = 0;
-let livesIcons = []; // Array for life icons
+let highScore = 0;
+let livesIcons = [];
+
 let scoreText;
-let wave = 0;
+let waveText;
+let comboText;
+let accuracyText;
+let highScoreText;
+let controlsHintText;
+
+let wave = 1;
+let kills = 0;
 let killStreak = 0;
+let combo = 0;
+let bestCombo = 0;
 let specialCharges = 0;
 let powerText = null;
 let powerTween = null;
 
-let enemies = []; // Array of enemy objects
+let enemies = [];
 let enemySpawnTimer = 0;
-let enemySpawnInterval = 2100; // ms
+let enemySpawnInterval = 2000;
 let lastEnemyId = 0;
+
 let gameOverGroup = null;
+let pauseOverlayGroup = null;
 let gameOver = false;
+let isPaused = false;
+let isMuted = false;
 window.gameOver = gameOver;
 
-
-const MIN_SPAWN_DISTANCE = ENEMY_WIDTH * 1.1; // Minimum horizontal distance between enemies
+let totalTypedChars = 0;
+let totalMistakes = 0;
 
 const config = {
     type: Phaser.AUTO,
@@ -59,13 +80,14 @@ const config = {
         parent: 'game-container'
     },
     scene: {
-        preload: preload,
-        create: create,
-        update: update,
+        preload,
+        create,
+        update,
     }
 };
 
 let game = null;
+
 function startGame() {
     if (!game) {
         game = new Phaser.Game(config);
@@ -88,62 +110,187 @@ function preload() {
     this.load.audio('enemy_death', 'assets/audio/enemy_death.wav');
 }
 
-function pickWord() {
-    let words = [];
-    if (wave < 8) {
-        words = words.concat(window.WORD_BANK.easy);
-    } else if (wave < 16) {
-        words = words.concat(window.WORD_BANK.easy, window.WORD_BANK.medium);
-    } else if (wave < 24) {
-        words = words.concat(window.WORD_BANK.easy, window.WORD_BANK.medium, window.WORD_BANK.hard);
-    } else {
-        words = words.concat(
-            window.WORD_BANK.easy,
-            window.WORD_BANK.medium,
-            window.WORD_BANK.hard,
-            window.WORD_BANK.insane
-        );
+function loadSaveData() {
+    try {
+        const raw = localStorage.getItem(SAVE_KEY);
+        if (!raw) return;
+        const parsed = JSON.parse(raw);
+        if (parsed && Number.isFinite(parsed.highScore)) {
+            highScore = parsed.highScore;
+        }
+    } catch (err) {
+        highScore = 0;
     }
-    return words[Math.floor(Math.random() * words.length)];
+}
+
+function persistSaveData() {
+    try {
+        localStorage.setItem(SAVE_KEY, JSON.stringify({ highScore }));
+    } catch (err) {
+        // ignore storage write failures
+    }
+}
+
+function validateWordBank() {
+    const buckets = ['easy', 'medium', 'hard', 'insane'];
+    const fallback = {
+        easy: ['sol', 'tip', 'key', 'gas', 'fee'],
+        medium: ['stake', 'guard', 'wallet', 'chain', 'safety'],
+        hard: ['airdrop', 'private', 'confirm', 'monitor', 'defense'],
+        insane: ['stronghold', 'validation', 'decentralized']
+    };
+
+    if (!window.WORD_BANK) {
+        window.WORD_BANK = fallback;
+        return;
+    }
+
+    for (const bucket of buckets) {
+        const list = window.WORD_BANK[bucket];
+        if (!Array.isArray(list) || list.length === 0) {
+            window.WORD_BANK[bucket] = fallback[bucket];
+            continue;
+        }
+
+        const cleaned = list
+            .filter((word) => typeof word === 'string')
+            .map((word) => word.trim().toLowerCase())
+            .filter((word) => /^[a-z]+$/.test(word) && word.length >= 3)
+            .filter((word, index, arr) => arr.indexOf(word) === index);
+
+        window.WORD_BANK[bucket] = cleaned.length ? cleaned : fallback[bucket];
+    }
+}
+
+function getDifficultyPool() {
+    if (wave < 8) {
+        return [...window.WORD_BANK.easy];
+    }
+    if (wave < 16) {
+        return [...window.WORD_BANK.easy, ...window.WORD_BANK.medium];
+    }
+    if (wave < 28) {
+        return [...window.WORD_BANK.medium, ...window.WORD_BANK.hard];
+    }
+    return [...window.WORD_BANK.medium, ...window.WORD_BANK.hard, ...window.WORD_BANK.insane];
+}
+
+function pickWord() {
+    const words = getDifficultyPool();
+    const activeWords = new Set(enemies.filter((e) => e.alive).map((e) => e.word));
+    const uniquePool = words.filter((word) => !activeWords.has(word));
+    const pool = uniquePool.length ? uniquePool : words;
+    return pool[Math.floor(Math.random() * pool.length)];
+}
+
+function getEnemyProfile() {
+    const baseSpeed = 1.8 + wave * 0.06;
+    const eliteChance = Math.min(0.34, 0.08 + wave * 0.01);
+    const elite = Math.random() < eliteChance;
+
+    return {
+        speed: elite ? baseSpeed * 1.35 : baseSpeed + Math.random() * 0.4,
+        hp: elite ? 2 : 1,
+        elite,
+        scoreValue: elite ? 3 : 1
+    };
 }
 
 function canSpawnNewEnemy() {
-    const living = enemies.filter(e => e.alive);
+    const living = enemies.filter((e) => e.alive);
     if (living.length === 0) return true;
-    let rightmost = Math.max(...living.map(e => e.sprite.x));
+    const rightmost = Math.max(...living.map((e) => e.sprite.x));
     return rightmost > MIN_SPAWN_DISTANCE;
 }
 
 function spawnEnemy(scene) {
-    let enemyStartX = -ENEMY_WIDTH / 10;
-    let spawnY = ENEMY_MIN_Y + Math.random() * (ENEMY_MAX_Y - ENEMY_MIN_Y);
-    let enemySprite = scene.add.sprite(enemyStartX, spawnY, 'enemy_1');
+    const enemyStartX = -ENEMY_WIDTH / 10;
+    const spawnY = ENEMY_MIN_Y + Math.random() * (ENEMY_MAX_Y - ENEMY_MIN_Y);
+    const profile = getEnemyProfile();
+
+    const enemySprite = scene.add.sprite(enemyStartX, spawnY, 'enemy_1');
     enemySprite.play('enemy_walk');
     enemySprite.setDisplaySize(ENEMY_WIDTH, ENEMY_HEIGHT);
     enemySprite.setOrigin(0.5, 1);
+    enemySprite.setTint(profile.elite ? 0xffd08a : 0xffffff);
 
-    let word = pickWord();
-    let text = scene.add.text(0, 0, word, {
+    const word = pickWord();
+    const text = scene.add.text(0, 0, word, {
         fontFamily: 'monospace',
-        fontSize: '32px',
-        color: '#fff200',
-        stroke: '#333',
-        strokeThickness: 6
+        fontSize: profile.elite ? '36px' : '32px',
+        color: profile.elite ? '#ffb347' : '#fff200',
+        stroke: '#2a1e00',
+        strokeThickness: profile.elite ? 7 : 6
     }).setOrigin(0.5);
 
-    let speed = 2 + (wave * 0.05) + Math.random() * 0.25;
-
-    let enemyObj = {
+    const enemyObj = {
         id: lastEnemyId++,
         sprite: enemySprite,
-        text: text,
-        word: word,
-        speed: speed,
-        vertical: false,
+        text,
+        word,
+        speed: profile.speed,
+        hp: profile.hp,
+        elite: profile.elite,
+        scoreValue: profile.scoreValue,
         alive: true,
-        arrowFiring: false
+        arrowFiring: false,
+        focus: false,
     };
+
     enemies.push(enemyObj);
+}
+
+function calculateMultiplier() {
+    return 1 + Math.floor(combo / 5);
+}
+
+function updateHud() {
+    if (scoreText) scoreText.setText(`Score: ${score}`);
+    if (waveText) waveText.setText(`Wave: ${wave}`);
+    if (comboText) comboText.setText(`Combo x${calculateMultiplier()} (${combo})`);
+
+    const attempts = totalTypedChars + totalMistakes;
+    const accuracy = attempts > 0 ? Math.round((totalTypedChars / attempts) * 100) : 100;
+    if (accuracyText) accuracyText.setText(`Accuracy: ${accuracy}%`);
+
+    if (highScoreText) {
+        highScoreText.setText(`Best: ${highScore}`);
+    }
+}
+
+function flashFeedback(scene, message, color = '#ffd34a') {
+    if (!feedbackText) return;
+    feedbackText.setText(message);
+    feedbackText.setColor(color);
+    scene.tweens.killTweensOf(feedbackText);
+    feedbackText.alpha = 1;
+    scene.tweens.add({
+        targets: feedbackText,
+        alpha: 0,
+        duration: 700,
+        ease: 'Cubic.easeOut'
+    });
+}
+
+function updateEnemyTextStyles() {
+    for (const enemyObj of enemies) {
+        if (!enemyObj.alive) continue;
+        const isPrefix = typed.length > 0 && enemyObj.word.startsWith(typed);
+        const isExact = typed.length > 0 && enemyObj.word === typed;
+
+        enemyObj.text.setStyle({
+            color: isExact ? '#7fff8f' : isPrefix ? '#8ff5ff' : enemyObj.elite ? '#ffb347' : '#fff200',
+            stroke: isPrefix ? '#003d46' : enemyObj.elite ? '#2a1e00' : '#333'
+        });
+    }
+}
+
+function chooseTargetEnemy() {
+    const candidates = enemies
+        .filter((e) => e.alive && !e.arrowFiring && e.word.startsWith(typed))
+        .sort((a, b) => b.sprite.x - a.sprite.x);
+
+    return candidates[0] || null;
 }
 
 function killEnemyWithArrow(scene, enemyObj) {
@@ -152,16 +299,16 @@ function killEnemyWithArrow(scene, enemyObj) {
     enemyObj.arrowFiring = true;
     archer.setTexture('archer_attack');
 
-    let arrowStartX = archer.x - 30;
-    let arrowStartY = archer.y - 18;
-    let arrowTargetX = enemyObj.sprite.x;
-    let arrowTargetY = enemyObj.sprite.y - ENEMY_HEIGHT / 2;
+    const arrowStartX = archer.x - 30;
+    const arrowStartY = archer.y - 18;
+    const arrowTargetX = enemyObj.sprite.x;
+    const arrowTargetY = enemyObj.sprite.y - ENEMY_HEIGHT / 2;
 
-    let dx = arrowTargetX - arrowStartX;
-    let dy = arrowTargetY - arrowStartY;
-    let angleDeg = Phaser.Math.RadToDeg(Math.atan2(dy, dx));
+    const dx = arrowTargetX - arrowStartX;
+    const dy = arrowTargetY - arrowStartY;
+    const angleDeg = Phaser.Math.RadToDeg(Math.atan2(dy, dx));
 
-    let arrow = scene.add.sprite(arrowStartX, arrowStartY, 'arrow');
+    const arrow = scene.add.sprite(arrowStartX, arrowStartY, 'arrow');
     arrow.setOrigin(0.3, 0.5);
     arrow.scaleX = -1;
     arrow.displayWidth = 250;
@@ -169,31 +316,65 @@ function killEnemyWithArrow(scene, enemyObj) {
     arrow.angle = angleDeg;
     scene.sound.play('arrow_shot', { volume: 0.4 });
 
-    let duration = Math.max(300, Phaser.Math.Distance.Between(arrowStartX, arrowStartY, arrowTargetX, arrowTargetY) / (ARROW_SPEED * 4) * 1000);
+    const duration = Math.max(
+        280,
+        (Phaser.Math.Distance.Between(arrowStartX, arrowStartY, arrowTargetX, arrowTargetY) / (ARROW_SPEED * 4)) * 1000
+    );
 
     scene.tweens.add({
         targets: arrow,
         x: arrowTargetX,
         y: arrowTargetY,
-        duration: duration,
+        duration,
         onComplete: () => {
+            arrow.destroy();
+
+            enemyObj.hp -= 1;
+            enemyObj.arrowFiring = false;
+
+            if (enemyObj.hp > 0) {
+                scene.sound.play('enemy_death', { volume: 0.3 });
+                enemyObj.sprite.setTint(0xff6666);
+                scene.tweens.add({
+                    targets: enemyObj.sprite,
+                    duration: 140,
+                    onComplete: () => {
+                        if (enemyObj.sprite) {
+                            enemyObj.sprite.setTint(enemyObj.elite ? 0xffd08a : 0xffffff);
+                        }
+                    }
+                });
+                archer.setTexture('archer_idle');
+                return;
+            }
+
+            enemyObj.alive = false;
             enemyObj.sprite.destroy();
             enemyObj.text.destroy();
-            arrow.destroy();
             scene.sound.play('enemy_death', { volume: 0.6 });
-            
-            enemyObj.alive = false;
-            enemies = enemies.filter(e => e.alive || e.id !== enemyObj.id);
-            
-            score += 1;
-            wave += 1;
+
+            kills += 1;
+            combo += 1;
             killStreak += 1;
+            bestCombo = Math.max(bestCombo, combo);
+
+            const gained = enemyObj.scoreValue * calculateMultiplier();
+            score += gained;
+            wave = 1 + Math.floor(kills / 4);
+
             if (killStreak % POWER_STREAK === 0 && specialCharges < MAX_POWER) {
                 specialCharges += 1;
-                updatePowerText(scene);
+                flashFeedback(scene, '+1 Honda Charge!', '#8be9fd');
             }
-            if (scoreText) scoreText.setText("Score: " + score);
-            
+
+            if (score > highScore) {
+                highScore = score;
+                persistSaveData();
+            }
+
+            updatePowerText(scene);
+            updateHud();
+            adjustSpawnRate();
             archer.setTexture('archer_idle');
         }
     });
@@ -202,16 +383,17 @@ function killEnemyWithArrow(scene, enemyObj) {
 function create() {
     const scene = this;
     window.currentScene = scene;
-    let bg = this.add.image(GAME_WIDTH / 2, GAME_HEIGHT / 2, 'background');
+
+    loadSaveData();
+    validateWordBank();
+
+    const bg = this.add.image(GAME_WIDTH / 2, GAME_HEIGHT / 2, 'background');
     bg.setDisplaySize(GAME_WIDTH, GAME_HEIGHT);
     bg.setOrigin(0.5, 0.5);
 
     this.anims.create({
         key: 'enemy_walk',
-        frames: [
-            { key: 'enemy_1' },
-            { key: 'enemy_2' }
-        ],
+        frames: [{ key: 'enemy_1' }, { key: 'enemy_2' }],
         frameRate: 4,
         repeat: -1
     });
@@ -220,66 +402,95 @@ function create() {
     archer.setDisplaySize(KING_WIDTH, KING_HEIGHT);
     archer.setOrigin(0.5, 0.9);
 
-    // Add Solflare title image instead of text
-    this.add.image(GAME_WIDTH / 2, 80, 'solflare_title')
-    .setOrigin(0.5)
-    .setScale(0.3); // 1.25x bigger than default, change this value as you wish
+    this.add.image(GAME_WIDTH / 2, 80, 'solflare_title').setOrigin(0.5).setScale(0.3);
 
+    typedText = this.add.text(GAME_WIDTH / 2, TYPED_TEXT_Y, '', {
+        fontFamily: 'monospace',
+        fontSize: '44px',
+        color: '#fffbe8',
+        backgroundColor: 'rgba(28,28,28,0.78)',
+        fontStyle: 'bold',
+        shadow: {
+            offsetX: 0,
+            offsetY: 3,
+            color: '#000',
+            blur: 8,
+            stroke: false,
+            fill: true
+        },
+        align: 'center',
+        padding: { x: 32, y: 10 }
+    }).setOrigin(0.5);
 
-    typedText = this.add.text(
-        GAME_WIDTH / 2, TYPED_TEXT_Y, "", {
-            fontFamily: 'monospace',
-            fontSize: '44px',
-            color: '#fffbe8',
-            backgroundColor: 'rgba(28,28,28,0.78)',
-            fontStyle: 'bold',
-            shadow: {
-                offsetX: 0, offsetY: 3, color: '#000',
-                blur: 8, stroke: false, fill: true
-            },
-            align: 'center',
-            padding: { x: 32, y: 10 }
-        }
-    ).setOrigin(0.5);
+    feedbackText = this.add.text(GAME_WIDTH / 2, TYPED_TEXT_Y + 64, '', {
+        fontFamily: 'monospace',
+        fontSize: '28px',
+        color: '#ffd34a',
+        stroke: '#151515',
+        strokeThickness: 5
+    }).setOrigin(0.5);
 
-    // Create life icons
-    for (let i = 0; i < 3; i++) {
-        let icon = this.add.image(GAME_WIDTH - 120 + (i * 40), 40, 'solicon');
+    for (let i = 0; i < 5; i++) {
+        const icon = this.add.image(GAME_WIDTH - 190 + i * 38, 40, 'solicon');
         icon.setDisplaySize(30, 30);
         livesIcons.push(icon);
     }
 
-    scoreText = this.add.text(120, 40, "Score: " + score, {
+    scoreText = this.add.text(80, 32, 'Score: 0', {
         fontFamily: 'monospace',
-        fontSize: '34px',
+        fontSize: '30px',
         color: '#fff'
-    }).setOrigin(0.5);
+    });
+
+    waveText = this.add.text(80, 70, 'Wave: 1', {
+        fontFamily: 'monospace',
+        fontSize: '28px',
+        color: '#9fe8ff'
+    });
+
+    comboText = this.add.text(80, 108, 'Combo x1 (0)', {
+        fontFamily: 'monospace',
+        fontSize: '28px',
+        color: '#9bffaf'
+    });
+
+    accuracyText = this.add.text(80, 146, 'Accuracy: 100%', {
+        fontFamily: 'monospace',
+        fontSize: '28px',
+        color: '#ffd68a'
+    });
+
+    highScoreText = this.add.text(80, 184, `Best: ${highScore}`, {
+        fontFamily: 'monospace',
+        fontSize: '28px',
+        color: '#ff92a6'
+    });
+
+    controlsHintText = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT - 26, 'SPACE = restart • P = pause • M = mute • type words to defend the gate', {
+        fontFamily: 'monospace',
+        fontSize: '24px',
+        color: '#f4f4f4',
+        backgroundColor: 'rgba(0,0,0,0.35)',
+        padding: { x: 12, y: 5 }
+    }).setOrigin(0.5, 1);
 
     powerText = this.add.text(GAME_WIDTH / 2, POWER_TEXT_Y, '', {
         fontFamily: '"Press Start 2P", monospace',
-        fontSize: '32px',
+        fontSize: '30px',
         fontStyle: 'bold',
         color: '#ff0000',
         stroke: '#000',
         strokeThickness: 6
     }).setOrigin(0.5);
 
-
-    // Debug lines
-// let graphics = this.add.graphics();
-// graphics.lineStyle(3, 0xff0000, 1);
-// graphics.lineBetween(DOOR_X, 0, DOOR_X, GAME_HEIGHT);
-// graphics.lineStyle(3, 0x00ff00, 1);
-// graphics.lineBetween(0, DOOR_Y, GAME_WIDTH, DOOR_Y);
-
-
-    // Start with two enemies spaced out
     spawnEnemy(this);
-    setTimeout(() => spawnEnemy(this), 900);
+    setTimeout(() => spawnEnemy(this), 800);
 
     enemySpawnTimer = 0;
-    enemySpawnInterval = 2100;
+    enemySpawnInterval = 2000;
+
     updatePowerText(this);
+    updateHud();
 
     window.handleTyping = (text) => {
         for (const ch of text) {
@@ -288,6 +499,16 @@ function create() {
     };
 
     this.input.keyboard.on('keydown', (event) => {
+        if (event.key === 'p' || event.key === 'P') {
+            togglePause(scene);
+            return;
+        }
+
+        if (event.key === 'm' || event.key === 'M') {
+            toggleMute(scene);
+            return;
+        }
+
         handleKeyInput(scene, event.key);
     });
 
@@ -298,8 +519,6 @@ function create() {
             if (window.hiddenInput) window.hiddenInput.focus();
         }
     });
-
-	
 }
 
 function update(time, delta) {
@@ -309,10 +528,10 @@ function update(time, delta) {
         window.gameOver = gameOver;
         return;
     }
-    if (gameOver) return;
 
-    // Clean up dead enemies first
-    enemies = enemies.filter(enemy => {
+    if (gameOver || isPaused) return;
+
+    enemies = enemies.filter((enemy) => {
         if (!enemy.alive) {
             if (enemy.sprite) enemy.sprite.destroy();
             if (enemy.text) enemy.text.destroy();
@@ -321,7 +540,6 @@ function update(time, delta) {
         return true;
     });
 
-    // Sync labels
     for (const enemyObj of enemies) {
         if (enemyObj.alive) {
             enemyObj.text.x = enemyObj.sprite.x;
@@ -329,9 +547,9 @@ function update(time, delta) {
         }
     }
 
-    // Move and update all enemies
     for (const enemyObj of enemies) {
         if (!enemyObj.alive) continue;
+
         if (enemyObj.sprite.x < DOOR_X) {
             enemyObj.sprite.x += enemyObj.speed;
             if (enemyObj.sprite.x >= DOOR_X) {
@@ -340,13 +558,11 @@ function update(time, delta) {
         }
     }
 
-    // Spawn new enemies
     enemySpawnTimer += delta;
     if (enemySpawnTimer > enemySpawnInterval && lives > 0) {
         if (canSpawnNewEnemy()) {
             spawnEnemy(this);
             enemySpawnTimer = 0;
-            enemySpawnInterval = Math.max(800, 2200 - wave * 40);
         }
     }
 }
@@ -354,22 +570,36 @@ function update(time, delta) {
 function showGameOverScreen(scene) {
     gameOverGroup = scene.add.group();
     window.gameOver = true;
-    const overlay = scene.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2, 600, 340, 0x181825, 0.97);
-    const text1 = scene.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 70, "GAME OVER", {
+
+    const overlay = scene.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2, 700, 420, 0x181825, 0.97);
+    const text1 = scene.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 120, 'GAME OVER', {
         fontFamily: 'monospace',
         fontSize: '72px',
         color: '#fffbe8'
     }).setOrigin(0.5);
 
-    const text2 = scene.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 10, `Scammers defeated: ${score}`, {
+    const text2 = scene.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 36, `Scammers defeated: ${kills}`, {
         fontFamily: 'monospace',
-        fontSize: '48px',
+        fontSize: '42px',
         color: '#ffa600'
     }).setOrigin(0.5);
 
-    const text3 = scene.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 100, 'Press SPACE or tap restart', {
+    const text3 = scene.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 20, `Best Combo: ${bestCombo} • Accuracy: ${accuracyText ? accuracyText.text.replace('Accuracy: ', '') : '100%'}`,
+        {
+            fontFamily: 'monospace',
+            fontSize: '30px',
+            color: '#7de5ff'
+        }).setOrigin(0.5);
+
+    const text4 = scene.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 86, `Final Score: ${score} • Best Score: ${highScore}`, {
         fontFamily: 'monospace',
         fontSize: '32px',
+        color: '#ff94b8'
+    }).setOrigin(0.5);
+
+    const text5 = scene.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 146, 'Press SPACE or tap restart', {
+        fontFamily: 'monospace',
+        fontSize: '28px',
         color: '#ff9600'
     }).setOrigin(0.5);
 
@@ -377,57 +607,93 @@ function showGameOverScreen(scene) {
     if (restartBtn) restartBtn.style.display = 'block';
     if (window.showRestartButton) window.showRestartButton();
 
-    gameOverGroup.addMultiple([overlay, text1, text2, text3]);
+    gameOverGroup.addMultiple([overlay, text1, text2, text3, text4, text5]);
 }
+
 function resetGame(scene) {
-    // Clean up
     if (gameOverGroup) {
         gameOverGroup.clear(true, true);
         gameOverGroup = null;
     }
-    // Destroy all enemies and arrows
-    enemies.forEach(e => {
+
+    if (pauseOverlayGroup) {
+        pauseOverlayGroup.clear(true, true);
+        pauseOverlayGroup = null;
+    }
+
+    enemies.forEach((e) => {
         if (e.sprite) e.sprite.destroy();
         if (e.text) e.text.destroy();
     });
+
     enemies = [];
-    // Reset lives, score, wave, icons
-    lives = 3;
+    lives = 5;
     score = 0;
-    wave = 0;
+    wave = 1;
+    kills = 0;
+    combo = 0;
     killStreak = 0;
+    bestCombo = 0;
     specialCharges = 0;
+    totalTypedChars = 0;
+    totalMistakes = 0;
+    typed = '';
+    isPaused = false;
+
     if (powerText) powerText.setText('');
-    if (powerTween) { powerTween.remove(); powerTween = null; }
+    if (powerTween) {
+        powerTween.remove();
+        powerTween = null;
+    }
+
     for (let i = 0; i < livesIcons.length; i++) {
         livesIcons[i].setVisible(true);
     }
-    if (scoreText) scoreText.setText("Score: " + score);
-    if (typedText) typedText.setText("");
-    typed = "";
-    // Restart enemy spawn
+
+    if (typedText) typedText.setText('');
+    if (feedbackText) feedbackText.setText('');
+
     enemySpawnTimer = 0;
-    enemySpawnInterval = 2100;
+    enemySpawnInterval = 2000;
+    lastEnemyId = 0;
+
     spawnEnemy(scene);
-    setTimeout(() => spawnEnemy(scene), 900);
-    // Reset game over flag
+    setTimeout(() => spawnEnemy(scene), 800);
+
     gameOver = false;
     window.gameOver = gameOver;
+
     const restartBtn = document.getElementById('restartButton');
     if (restartBtn) restartBtn.style.display = 'none';
     if (window.hideRestartButton) window.hideRestartButton();
     if (window.hiddenInput) window.hiddenInput.focus();
+
+    updatePowerText(scene);
+    updateHud();
+}
+
+function adjustSpawnRate() {
+    const attempts = totalTypedChars + totalMistakes;
+    const accuracy = attempts > 0 ? totalTypedChars / attempts : 1;
+
+    const base = 2200 - wave * 35;
+    const comboBonus = Math.min(360, combo * 15);
+    const accuracyPenalty = accuracy < 0.8 ? 320 : accuracy < 0.9 ? 180 : 0;
+
+    enemySpawnInterval = Phaser.Math.Clamp(base - comboBonus + accuracyPenalty, 760, 2400);
 }
 
 function updatePowerText(scene) {
     if (!powerText) return;
+
     if (specialCharges > 0) {
         powerText.setText(`type ${POWER_WORD} to unleash the beast! x${specialCharges}`);
         if (powerTween) powerTween.remove();
+
         powerTween = scene.tweens.addCounter({
             from: 0,
             to: 360,
-            duration: 4000,
+            duration: 3500,
             repeat: -1,
             onUpdate: (tw) => {
                 const h = tw.getValue() / 360;
@@ -435,25 +701,38 @@ function updatePowerText(scene) {
                 powerText.setColor(c.rgba);
             }
         });
-    } else {
-        powerText.setText('');
-        if (powerTween) {
-            powerTween.remove();
-            powerTween = null;
-        }
+        return;
+    }
+
+    powerText.setText('');
+    if (powerTween) {
+        powerTween.remove();
+        powerTween = null;
     }
 }
 
 function killEnemyWithCar(scene, enemyObj) {
     if (!enemyObj.alive) return;
+
     enemyObj.sprite.destroy();
     enemyObj.text.destroy();
     enemyObj.alive = false;
+
     scene.sound.play('enemy_death', { volume: 0.6 });
-    score += 1;
-    wave += 1;
-    if (scoreText) scoreText.setText("Score: " + score);
-    updatePowerText(scene);
+
+    kills += 1;
+    combo += 1;
+    const gained = enemyObj.scoreValue * calculateMultiplier();
+    score += gained;
+    wave = 1 + Math.floor(kills / 4);
+
+    if (score > highScore) {
+        highScore = score;
+        persistSaveData();
+    }
+
+    updateHud();
+    adjustSpawnRate();
 }
 
 function activateCarPower(scene) {
@@ -461,12 +740,13 @@ function activateCarPower(scene) {
     car.setOrigin(0.5, 1);
     car.setScale(0.4);
     car.scaleX = -Math.abs(car.scaleX);
+
     scene.tweens.add({
         targets: car,
         x: -200,
         duration: (GAME_WIDTH + 300) / CAR_SPEED,
         onUpdate: () => {
-            enemies.forEach(e => {
+            enemies.forEach((e) => {
                 if (e.alive && car.x <= e.sprite.x) {
                     killEnemyWithCar(scene, e);
                 }
@@ -474,6 +754,8 @@ function activateCarPower(scene) {
         },
         onComplete: () => car.destroy()
     });
+
+    flashFeedback(scene, 'ROAD RAGE ACTIVATED!', '#ff9f4a');
 }
 
 function enemyReachedDoor(scene, enemyObj) {
@@ -481,28 +763,79 @@ function enemyReachedDoor(scene, enemyObj) {
         targets: enemyObj.sprite,
         y: enemyObj.sprite.y - DOOR_ENTRY_OFFSET,
         alpha: 0,
-        duration: 250,
+        duration: 230,
         onComplete: () => {
             enemyObj.alive = false;
             enemyObj.sprite.destroy();
             enemyObj.text.destroy();
         }
     });
+
     lives -= 1;
+    combo = 0;
     killStreak = 0;
+
     if (livesIcons[lives]) {
         livesIcons[lives].setVisible(false);
     }
+
+    flashFeedback(scene, 'Gate Hit! Combo reset.', '#ff7c7c');
     updatePowerText(scene);
+    updateHud();
 }
+
+function togglePause(scene) {
+    if (gameOver) return;
+
+    isPaused = !isPaused;
+
+    if (isPaused) {
+        pauseOverlayGroup = scene.add.group();
+        const rect = scene.add.rectangle(GAME_WIDTH / 2, GAME_HEIGHT / 2, 600, 220, 0x111111, 0.86);
+        const txt = scene.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 20, 'PAUSED', {
+            fontFamily: 'monospace',
+            fontSize: '72px',
+            color: '#fff'
+        }).setOrigin(0.5);
+
+        const txt2 = scene.add.text(GAME_WIDTH / 2, GAME_HEIGHT / 2 + 56, 'Press P to resume', {
+            fontFamily: 'monospace',
+            fontSize: '28px',
+            color: '#9fe8ff'
+        }).setOrigin(0.5);
+
+        pauseOverlayGroup.addMultiple([rect, txt, txt2]);
+        return;
+    }
+
+    if (pauseOverlayGroup) {
+        pauseOverlayGroup.clear(true, true);
+        pauseOverlayGroup = null;
+    }
+}
+
+function toggleMute(scene) {
+    isMuted = !isMuted;
+    scene.sound.mute = isMuted;
+    flashFeedback(scene, isMuted ? 'Muted' : 'Sound On', isMuted ? '#ffcf7c' : '#7cffb0');
+}
+
+window.togglePauseGame = () => {
+    if (window.currentScene) togglePause(window.currentScene);
+};
+
+window.toggleMuteGame = () => {
+    if (window.currentScene) toggleMute(window.currentScene);
+};
 
 window.resetGame = resetGame;
 
 function handleKeyInput(scene, key) {
-    if (lives === 0) return;
+    if (lives === 0 || gameOver || isPaused) return;
 
     if (/^[a-zA-Z]$/.test(key)) {
         typed += key.toLowerCase();
+        totalTypedChars += 1;
     } else if (key === 'Backspace' || key === '\b') {
         typed = '';
         if (window.hiddenInput) window.hiddenInput.value = '';
@@ -523,23 +856,29 @@ function handleKeyInput(scene, key) {
         return;
     }
 
-    if (typed.length >= POWER_WORD.length) {
-        const matchAny = enemies.some(e => e.alive && e.word.startsWith(typed));
-        const pwPrefix = POWER_WORD.startsWith(typed);
-        if (!matchAny && !pwPrefix) {
-            typed = '';
-            if (window.hiddenInput) window.hiddenInput.value = '';
-        }
+    const targetEnemy = chooseTargetEnemy();
+    const hasPrefixMatch = Boolean(targetEnemy);
+    const pwPrefix = POWER_WORD.startsWith(typed);
+
+    if (!hasPrefixMatch && !pwPrefix && typed.length > 0) {
+        totalMistakes += typed.length;
+        combo = 0;
+        typed = '';
+        if (window.hiddenInput) window.hiddenInput.value = '';
+        flashFeedback(scene, 'Miss! Combo reset.', '#ff7d7d');
     }
 
     if (typedText) typedText.setText(typed);
 
-    const matchedEnemy = enemies.find(e => e.alive && !e.arrowFiring && typed === e.word);
+    updateEnemyTextStyles();
+    updateHud();
+
+    const matchedEnemy = enemies.find((e) => e.alive && !e.arrowFiring && typed === e.word);
     if (matchedEnemy) {
         killEnemyWithArrow(scene, matchedEnemy);
         typed = '';
         if (typedText) typedText.setText('');
         if (window.hiddenInput) window.hiddenInput.value = '';
+        updateEnemyTextStyles();
     }
 }
-

--- a/index.html
+++ b/index.html
@@ -12,10 +12,23 @@
 <body>
   <div id="game-container"></div>
   <input id="hiddenInput" type="text" autocomplete="off" />
+
+  <div id="floatingControls">
+    <button id="pauseButton" class="hudButton">Pause (P)</button>
+    <button id="muteButton" class="hudButton">Mute (M)</button>
+  </div>
+
   <div id="startScreen">
     <img id="titleImage" src="assets/solflare_title.png" alt="Solflare" />
+    <p id="subtitle">Stronghold v2 • Defend your gate with speed, accuracy, and combos.</p>
+    <ul id="featureList">
+      <li>Adaptive enemy scaling and elite threats</li>
+      <li>Combo multiplier, accuracy tracking, and personal high score</li>
+      <li>Pause / mute controls + improved mobile keyboard support</li>
+    </ul>
     <button id="startButton">Start</button>
   </div>
+
   <button id="restartButton">Restart</button>
 
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
@@ -24,6 +37,8 @@
   <script>
     const startBtn = document.getElementById('startButton');
     const restartBtn = document.getElementById('restartButton');
+    const pauseBtn = document.getElementById('pauseButton');
+    const muteBtn = document.getElementById('muteButton');
     const hiddenInput = document.getElementById('hiddenInput');
     const startScreen = document.getElementById('startScreen');
     const gameContainer = document.getElementById('game-container');
@@ -37,6 +52,16 @@
     }
 
     startBtn.addEventListener('click', launchGame);
+
+    pauseBtn.addEventListener('click', () => {
+      if (window.togglePauseGame) window.togglePauseGame();
+      hiddenInput.focus();
+    });
+
+    muteBtn.addEventListener('click', () => {
+      if (window.toggleMuteGame) window.toggleMuteGame();
+      hiddenInput.focus();
+    });
 
     window.addEventListener('keydown', (e) => {
       if (e.code === 'Space') {
@@ -60,6 +85,7 @@
       restartBtn.style.display = 'block';
       hiddenInput.focus();
     };
+
     window.hideRestartButton = () => {
       restartBtn.style.display = 'none';
     };
@@ -72,6 +98,7 @@
         gameContainer.classList.add('keyboard-open');
       }
     });
+
     hiddenInput.addEventListener('blur', () => {
       if (isMobile) {
         gameContainer.classList.remove('keyboard-open');
@@ -96,4 +123,3 @@
   </script>
 </body>
 </html>
-

--- a/style.css
+++ b/style.css
@@ -4,32 +4,13 @@ body {
   overflow: hidden;
   overscroll-behavior: contain;
   touch-action: none;
+  font-family: 'Press Start 2P', monospace;
 }
 
 #hiddenInput {
   position: absolute;
   top: -100px;
   opacity: 0;
-}
-
-#startButton {
-  padding: 20px 40px;
-  font-size: 24px;
-  z-index: 10;
-  font-family: 'Press Start 2P', monospace;
-  margin-top: 40px;
-}
-
-#restartButton {
-  padding: 20px 40px;
-  font-size: 24px;
-  z-index: 30;
-  font-family: 'Press Start 2P', monospace;
-  position: absolute;
-  top: calc(50% + 220px);
-  left: 50%;
-  transform: translateX(-50%);
-  display: none;
 }
 
 canvas {
@@ -51,22 +32,110 @@ canvas {
   transform: translateY(-15vh);
 }
 
+#floatingControls {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 35;
+  display: flex;
+  gap: 10px;
+}
+
+.hudButton {
+  background: rgba(0, 0, 0, 0.72);
+  border: 2px solid #7de5ff;
+  color: #d8f8ff;
+  padding: 10px 14px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.hudButton:hover {
+  background: rgba(33, 58, 77, 0.85);
+}
+
+#startButton,
+#restartButton {
+  padding: 18px 34px;
+  font-size: 20px;
+  z-index: 30;
+  font-family: 'Press Start 2P', monospace;
+  background: #0b1824;
+  color: #d9f5ff;
+  border: 3px solid #74d4ff;
+  cursor: pointer;
+}
+
+#startButton {
+  margin-top: 28px;
+}
+
+#restartButton {
+  position: absolute;
+  top: calc(50% + 250px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: none;
+}
+
 #startScreen {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  background: #5bb0ff;
+  background: linear-gradient(180deg, #77bcff 0%, #65aaf0 55%, #4c93d8 100%);
   z-index: 20;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  text-align: center;
+  color: #13253a;
 }
 
 #titleImage {
   width: 60%;
-  max-width: 600px;
-  margin-bottom: 60px;
+  max-width: 640px;
+  margin-bottom: 24px;
+}
+
+#subtitle {
+  max-width: 980px;
+  line-height: 1.5;
+  font-size: 14px;
+  margin: 0 24px 16px;
+}
+
+#featureList {
+  margin: 0;
+  max-width: 980px;
+  text-align: left;
+  line-height: 1.5;
+  font-size: 12px;
+}
+
+#featureList li {
+  margin-bottom: 10px;
+}
+
+@media (max-width: 980px) {
+  #titleImage {
+    width: 90%;
+  }
+
+  #subtitle,
+  #featureList {
+    font-size: 10px;
+    max-width: 90vw;
+  }
+
+  #startButton,
+  #restartButton {
+    font-size: 14px;
+  }
+
+  .hudButton {
+    font-size: 10px;
+  }
 }

--- a/word_bank.js
+++ b/word_bank.js
@@ -1,17 +1,20 @@
 window.WORD_BANK = {
     easy: [
-        "sol","nft","dao","key","buy","pay","dex","gas","fee","tip","fud","txs",
-        "api","bin","bot","eth","btc"
+        'sol', 'nft', 'dao', 'key', 'buy', 'pay', 'dex', 'gas', 'fee', 'tip',
+        'fud', 'txs', 'api', 'bot', 'eth', 'btc', 'mint', 'send', 'hold', 'sign'
     ],
     medium: [
-        "mint","swap","send","hold","txid","burn","seed","coin","sign","lend","earn",
-        "vote","lock","hodl","dapp","swap","save","code","cold","safe","test"
+        'swap', 'burn', 'seed', 'coin', 'lend', 'earn', 'vote', 'lock', 'dapp',
+        'save', 'code', 'cold', 'safe', 'test', 'guard', 'shield', 'audit', 'alert',
+        'payer', 'owner', 'token', 'vault'
     ],
     hard: [
-        "trade","vault","claim","split","yield","block","stake","token","chain","value",
-        "slash","payer","refer","admin","alert","guard","input","smart"
+        'wallet', 'phrase', 'backup', 'domain', 'ransom', 'spoofed', 'airdrop',
+        'confirm', 'defense', 'private', 'monitor', 'session', 'staking', 'phantom',
+        'cluster', 'sandbox', 'account', 'solana', 'program', 'network'
     ],
     insane: [
-        "strong","solana"
+        'stronghold', 'validation', 'decentralized', 'multisignature', 'cryptography',
+        'counterparty', 'immutability', 'permissionless'
     ]
 };


### PR DESCRIPTION
### Motivation
- Modernize and rebalance the game loop to make v2 feel more engaging and skillful with clear progression and feedback. 
- Improve stability by sanitizing and validating the runtime word bank and avoiding duplicate active words. 
- Add quality-of-life features (pause/mute, mobile input flow, persistent high score) and a clearer HUD/start screen so players can understand new mechanics. 

### Description
- Rewrote and reorganized the core game logic in `game.js` including new save/load helpers (`loadSaveData`, `persistSaveData`), runtime word-bank validation (`validateWordBank`), adaptive spawning (`adjustSpawnRate`), elite enemy profiles (`getEnemyProfile`), and improved word selection (`pickWord`).
- Introduced skill systems and metrics: combo multiplier, accuracy tracking (`totalTypedChars`, `totalMistakes`), kill streak rewards, per-enemy HP/score values, and richer HUD updates (`updateHud`, `flashFeedback`, `updateEnemyTextStyles`).
- Added pause/mute controls and UI glue: `togglePause`, `toggleMute`, global helpers `window.togglePauseGame` / `window.toggleMuteGame`, on-screen floating buttons and keyboard handlers in `index.html`, and mobile keyboard focus handling.
- UX and style refresh: updated `index.html` start screen copy and buttons, added `style.css` improvements (floating HUD buttons, responsive start screen, button styling), and expanded `README.md` documenting v2 features.
- Expanded and sanitized the word list in `word_bank.js` and added safe fallbacks so gameplay is stable even if external lists are malformed.

### Testing
- Ran `node --check game.js` which completed successfully. 
- Ran `node --check word_bank.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c66de07ccc832492870f30689fd354)